### PR TITLE
AB#8 Configure email in Azure Communication Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,34 @@ the UI project, `Fonbec.Web.Ui` &rarr; Manage User Secrets) with this format:
 ```
 
 Assign a value to each field.
+
+ASP.NET Core Identity relies on classes that send emails.  For that purpose,
+this needs to be set in the user secrets too:
+
+```
+"Email": {
+  "From": "",
+  "ReplyToEmail": "",
+  "ReplyToDisplayName": ""
+}
+```
+
+`From` is the email address that emails are sent from.  It must be an address
+from a verified domain (by default in the domain `azurecomm.net`).  The other
+two fields are optional.
+
+The email sender service has `EmailClient` as a dependency, which is defined in
+the `Azure.Communications.Email` namespace.  Its instantiation requires a
+connection string, so this must be added to the secrets as well:
+
+```
+"ConnectionStrings": {
+  "CommunicationServiceConnectionString": ""
+}
+```
+
+Ask a colleague for the connection string to Azure Communication Service.
+Alternatively, you can use the `IdentityNoOpEmailSender` in the IoC container
+registration for `IEmailSender<FonbecWebUser>` (but you'll have to get back
+code in the `RegisterConfirmation.razor`; check git history for that, for
+example in commit 934513470a789143bd45f295c400a4e82852ae18).

--- a/src/1-UI/Fonbec.Web.Ui/Account/Communication/EmailSender.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Account/Communication/EmailSender.cs
@@ -1,0 +1,29 @@
+﻿using Fonbec.Web.Logic.Builders;
+using Fonbec.Web.Logic.Models;
+using Fonbec.Web.Logic.Services;
+using Microsoft.AspNetCore.Identity.UI.Services;
+
+namespace Fonbec.Web.Ui.Account.Communication;
+
+public class EmailSender(
+    ILogger<EmailSender> logger,
+    IConfiguration configuration,
+    IEmailSenderService emailSenderService)
+    : IEmailSender
+{
+    public async Task SendEmailAsync(string email, string subject, string htmlMessage)
+    {
+        logger.LogDebug("Sending email to {To} with subject '{Subject}' and body '{Body}'.",
+            email,
+            subject,
+            htmlMessage);
+
+        List<Recipient> recipients = [new(email)];
+
+        var emailMessageBuilder = new EmailMessageBuilder(configuration, recipients, subject, htmlMessage);
+
+        var emailMessage = emailMessageBuilder.Build();
+
+        await emailSenderService.SendEmailAsync(emailMessage);
+    }
+}

--- a/src/1-UI/Fonbec.Web.Ui/Account/Communication/IdentityEmailSender.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Account/Communication/IdentityEmailSender.cs
@@ -1,0 +1,23 @@
+﻿using Fonbec.Web.DataAccess.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+
+namespace Fonbec.Web.Ui.Account.Communication;
+
+internal sealed class IdentityEmailSender(IEmailSender emailSender) : IEmailSender<FonbecWebUser>
+{
+    public async Task SendConfirmationLinkAsync(FonbecWebUser user, string email, string confirmationLink)
+    {
+        await emailSender.SendEmailAsync(email, "Confirmá tu correo electrónico", $"Confirmá tu correo electrónico <a href='{confirmationLink}'>haciendo clic acá</a>.");
+    }
+
+    public async Task SendPasswordResetLinkAsync(FonbecWebUser user, string email, string resetLink)
+    {
+        await emailSender.SendEmailAsync(email, "Reseteá tu contraseña", $"Reseteá tu contraseña <a href='{resetLink}'>haciendo clic acá</a>.");
+    }
+
+    public async Task SendPasswordResetCodeAsync(FonbecWebUser user, string email, string resetCode)
+    {
+        await emailSender.SendEmailAsync(email, "Reseteá tu contraseña", $"Reseteá tu contraseña usando este código: {resetCode}");
+    }
+}

--- a/src/1-UI/Fonbec.Web.Ui/Account/Communication/IdentityNoOpEmailSender.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Account/Communication/IdentityNoOpEmailSender.cs
@@ -2,7 +2,7 @@ using Fonbec.Web.DataAccess.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 
-namespace Fonbec.Web.Ui.Account;
+namespace Fonbec.Web.Ui.Account.Communication;
 
 // Remove the "else if (EmailSender is IdentityNoOpEmailSender)" block from RegisterConfirmation.razor after updating with a real implementation.
 internal sealed class IdentityNoOpEmailSender : IEmailSender<FonbecWebUser>

--- a/src/1-UI/Fonbec.Web.Ui/Account/Pages/RegisterConfirmation.razor
+++ b/src/1-UI/Fonbec.Web.Ui/Account/Pages/RegisterConfirmation.razor
@@ -1,13 +1,9 @@
 ﻿@page "/Account/RegisterConfirmation"
 
-@using System.Text
 @using Fonbec.Web.DataAccess.Entities
 @using Microsoft.AspNetCore.Identity
-@using Microsoft.AspNetCore.WebUtilities
 
 @inject UserManager<FonbecWebUser> UserManager
-@inject IEmailSender<FonbecWebUser> EmailSender
-@inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
 
 <PageTitle>Register confirmation</PageTitle>
@@ -16,20 +12,9 @@
 
 <StatusMessage Message="@_statusMessage" />
 
-@if (_emailConfirmationLink is not null)
-{
-    <p>
-        This app does not currently have a real email sender registered, see <a class="mud-link mud-primary-text mud-link-underline-hover" href="https://aka.ms/aspaccountconf">these docs</a> for how to configure a real email sender.
-        Normally this would be emailed: <a class="mud-link mud-primary-text mud-link-underline-hover" href="@_emailConfirmationLink">Click here to confirm your account</a>
-    </p>
-}
-else
-{
-    <p role="alert">Please check your email to confirm your account.</p>
-}
+<p role="alert">Please check your email to confirm your account.</p>
 
 @code {
-    private string? _emailConfirmationLink;
     private string? _statusMessage;
 
     [CascadingParameter]
@@ -53,16 +38,6 @@ else
         {
             HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
             _statusMessage = "Error finding user for unspecified email";
-        }
-        else if (EmailSender is IdentityNoOpEmailSender)
-        {
-            // Once you add a real email sender, you should remove this code that lets you confirm the account
-            var userId = await UserManager.GetUserIdAsync(user);
-            var code = await UserManager.GenerateEmailConfirmationTokenAsync(user);
-            code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
-            _emailConfirmationLink = NavigationManager.GetUriWithQueryParameters(
-                NavigationManager.ToAbsoluteUri("Account/ConfirmEmail").AbsoluteUri,
-                new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code, ["returnUrl"] = ReturnUrl });
         }
     }
 }

--- a/src/1-UI/Fonbec.Web.Ui/Configuration/ConfigureServices.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Configuration/ConfigureServices.cs
@@ -1,11 +1,13 @@
-﻿using Fonbec.Web.DataAccess;
+﻿using Azure.Communication.Email;
+using Fonbec.Web.DataAccess;
 using Fonbec.Web.DataAccess.Constants;
 using Fonbec.Web.DataAccess.Entities;
 using Fonbec.Web.DataAccess.Repositories;
 using Fonbec.Web.Logic.Services;
-using Fonbec.Web.Ui.Account;
+using Fonbec.Web.Ui.Account.Communication;
 using Fonbec.Web.Ui.Options;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Options;
@@ -24,13 +26,19 @@ public static class ConfigureServices
             configuration.GetSection(AdminUserOptions.SectionName));
     }
 
-    public static void RegisterServices(IServiceCollection services)
+    public static void RegisterServices(IServiceCollection services, IConfiguration configuration)
     {
         services.AddMudServices();
 
         services.AddMudExtensions();
 
-        services.AddSingleton<IEmailSender<FonbecWebUser>, IdentityNoOpEmailSender>();
+        services.AddSingleton<IEmailSender<FonbecWebUser>, IdentityEmailSender>();
+        services.AddSingleton<IEmailSender, EmailSender>();
+        services.AddSingleton<IEmailSenderService, EmailSenderService>();
+
+        var communicationServiceConnectionString =
+            configuration.GetConnectionString("CommunicationServiceConnectionString");
+        services.AddSingleton(_ => new EmailClient(communicationServiceConnectionString));
 
         services.AddScoped<IChaptersListService, ChaptersListService>();
 

--- a/src/1-UI/Fonbec.Web.Ui/Program.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Program.cs
@@ -37,7 +37,7 @@ builder.Services.AddIdentityCore<FonbecWebUser>(options =>
 
 ConfigureServices.RegisterOptions(builder.Services, builder.Configuration);
 
-ConfigureServices.RegisterServices(builder.Services);
+ConfigureServices.RegisterServices(builder.Services, builder.Configuration);
 
 ConfigureServices.RegisterEntityFrameworkCore(builder.Services, builder.Configuration);
 

--- a/src/2-Logic/Fonbec.Web.Logic/Builders/EmailMessageBuilder.cs
+++ b/src/2-Logic/Fonbec.Web.Logic/Builders/EmailMessageBuilder.cs
@@ -1,0 +1,98 @@
+﻿using Azure.Communication.Email;
+using Fonbec.Web.Logic.Models;
+using Microsoft.Extensions.Configuration;
+using System.Net.Mime;
+
+namespace Fonbec.Web.Logic.Builders;
+
+public class EmailMessageBuilder
+{
+    private readonly string _from;
+
+    public EmailMessageBuilder(IConfiguration configuration,
+        List<Recipient> to,
+        string subject,
+        string bodyHtml)
+    {
+        _from = configuration.GetSection("Email:From").Value
+                ?? throw new NullReferenceException("Email:From not set.");
+
+        var replyToEmail = configuration.GetSection("Email:ReplyToEmail").Value;
+        if (replyToEmail is not null && !string.IsNullOrWhiteSpace(replyToEmail))
+        {
+            var replyToDisplayName = configuration.GetSection("Email:ReplyToDisplayName").Value;
+            var displayName = replyToDisplayName is null || string.IsNullOrWhiteSpace(replyToDisplayName)
+                ? replyToEmail
+                : replyToDisplayName;
+            ReplyTo = new Recipient(replyToEmail, displayName);
+        }
+
+        To = to;
+        Subject = subject;
+        BodyHtml = bodyHtml;
+    }
+
+    public List<Recipient> To { get; }
+
+    public List<Recipient> Cc { get; } = [];
+
+    public List<Recipient> Bcc { get; } = [];
+
+    public Recipient? ReplyTo { get; }
+
+    public string Subject { get; }
+
+    public string BodyHtml { get; }
+
+    public string? BodyPlainText { get; set; }
+
+    public List<string> FilePaths { get; } = [];
+
+    public EmailMessage Build()
+    {
+        var emailContent = new EmailContent(Subject)
+        {
+            Html = BodyHtml,
+            PlainText = BodyPlainText
+        };
+
+        var to = To.Select(r => new EmailAddress(r.EmailAddress, r.DisplayName));
+        var cc = Cc.Any()
+            ? Cc.Select(r => new EmailAddress(r.EmailAddress, r.DisplayName))
+            : null;
+        var bcc = Bcc.Any()
+            ? Bcc.Select(r => new EmailAddress(r.EmailAddress, r.DisplayName))
+            : null;
+        var emailRecipients = new EmailRecipients(to, cc, bcc);
+
+        EmailMessage emailMessage;
+        if (ReplyTo is null)
+        {
+            emailMessage = new EmailMessage(_from, emailRecipients, emailContent);
+        }
+        else
+        {
+            emailMessage = new EmailMessage(_from, emailRecipients, emailContent)
+            {
+                ReplyTo = { new EmailAddress(ReplyTo.EmailAddress, ReplyTo.DisplayName) }
+            };
+        }
+
+        foreach (var filePath in FilePaths)
+        {
+            var fileInfo = new FileInfo(filePath);
+            var fileName = fileInfo.Name;
+            var contentType = fileInfo.Extension.Equals(".pdf", StringComparison.OrdinalIgnoreCase)
+                ? MediaTypeNames.Application.Pdf
+                : MediaTypeNames.Application.Octet;
+
+            var bytes = File.ReadAllBytes(filePath);
+            var binaryData = new BinaryData(bytes);
+            var emailAttachment = new EmailAttachment(fileName, contentType, binaryData);
+
+            emailMessage.Attachments.Add(emailAttachment);
+        }
+
+        return emailMessage;
+    }
+}

--- a/src/2-Logic/Fonbec.Web.Logic/Fonbec.Web.Logic.csproj
+++ b/src/2-Logic/Fonbec.Web.Logic/Fonbec.Web.Logic.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Azure.Communication.Email" Version="1.0.1" />
     <PackageReference Include="Mapster" Version="7.4.0" />
   </ItemGroup>
 

--- a/src/2-Logic/Fonbec.Web.Logic/Models/Recipient.cs
+++ b/src/2-Logic/Fonbec.Web.Logic/Models/Recipient.cs
@@ -1,0 +1,17 @@
+﻿namespace Fonbec.Web.Logic.Models;
+
+public class Recipient
+{
+    public Recipient(string emailAddress, string? displayName = null)
+    {
+        var displayNameToUse = displayName ?? emailAddress;
+        DisplayName = displayNameToUse.Contains(' ')
+            ? $"\"{displayNameToUse}\""
+            : displayNameToUse;
+        EmailAddress = $"<{emailAddress}>";
+    }
+
+    public string DisplayName { get; }
+
+    public string EmailAddress { get; }
+}

--- a/src/2-Logic/Fonbec.Web.Logic/Services/EmailSenderService.cs
+++ b/src/2-Logic/Fonbec.Web.Logic/Services/EmailSenderService.cs
@@ -1,0 +1,47 @@
+﻿using Azure;
+using Azure.Communication.Email;
+using Microsoft.Extensions.Logging;
+
+namespace Fonbec.Web.Logic.Services;
+
+public interface IEmailSenderService
+{
+    Task SendEmailAsync(EmailMessage emailMessage);
+}
+
+public class EmailSenderService(ILogger<EmailSenderService> logger, EmailClient emailClient) : IEmailSenderService
+{
+    public async Task SendEmailAsync(EmailMessage emailMessage)
+    {
+        if (emailMessage is null)
+        {
+            logger.LogError("EmailMessage parameter is null.");
+            throw new ArgumentNullException(nameof(emailMessage));
+        }
+
+        try
+        {
+            var emailSendOperation = await emailClient.SendAsync(
+                WaitUntil.Completed,
+                emailMessage);
+
+            if (emailSendOperation.HasValue)
+            {
+                logger.LogDebug("Email queued for delivery. Status = {Status}", emailSendOperation.Value.Status);
+            }
+            else
+            {
+                logger.LogWarning("Email send operation completed but no value was returned. OperationId = {OperationId}", emailSendOperation.Id);
+            }
+
+            // The OperationId can be used for tracking the message for troubleshooting
+            logger.LogDebug("Email operation id = {OperationId}", emailSendOperation.Id);
+        }
+        catch (RequestFailedException ex)
+        {
+            // OperationID is contained in the exception message and can be used for troubleshooting purposes
+            logger.LogError("Email send operation failed with error code: {ErrorCode}, message: {Message}", ex.ErrorCode, ex.Message);
+            throw;
+        }
+    }
+}

--- a/test/Fonbec.Web.Logic.Tests/Builders/EmailMessageBuilderTests.cs
+++ b/test/Fonbec.Web.Logic.Tests/Builders/EmailMessageBuilderTests.cs
@@ -61,7 +61,7 @@ public class EmailMessageBuilderTests
         {
             emailMessage.SenderAddress.Should().Be("from@email.com");
 
-            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Should().ContainSingle();
             emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
             emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
 
@@ -108,11 +108,11 @@ public class EmailMessageBuilderTests
         {
             emailMessage.SenderAddress.Should().Be("from@email.com");
 
-            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Should().ContainSingle();
             emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
             emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
 
-            emailMessage.ReplyTo.Should().HaveCount(1);
+            emailMessage.ReplyTo.Should().ContainSingle();
             emailMessage.ReplyTo.Single().Address.Should().Be("<reply-to@email.com>");
             emailMessage.ReplyTo.Single().DisplayName.Should().Be("reply-to@email.com");
 
@@ -165,11 +165,11 @@ public class EmailMessageBuilderTests
         {
             emailMessage.SenderAddress.Should().Be("from@email.com");
 
-            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Should().ContainSingle();
             emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
             emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
 
-            emailMessage.ReplyTo.Should().HaveCount(1);
+            emailMessage.ReplyTo.Should().ContainSingle();
             emailMessage.ReplyTo.Single().Address.Should().Be("<reply-to@email.com>");
             emailMessage.ReplyTo.Single().DisplayName.Should().Be("\"ReplyTo Display Name\"");
 
@@ -221,7 +221,7 @@ public class EmailMessageBuilderTests
         {
             emailMessage.SenderAddress.Should().Be("from@email.com");
 
-            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Should().ContainSingle();
             emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
             emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
 
@@ -274,7 +274,7 @@ public class EmailMessageBuilderTests
         {
             emailMessage.SenderAddress.Should().Be("from@email.com");
 
-            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Should().ContainSingle();
             emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
             emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
 

--- a/test/Fonbec.Web.Logic.Tests/Builders/EmailMessageBuilderTests.cs
+++ b/test/Fonbec.Web.Logic.Tests/Builders/EmailMessageBuilderTests.cs
@@ -1,0 +1,295 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using Fonbec.Web.Logic.Builders;
+using Fonbec.Web.Logic.Models;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+
+namespace Fonbec.Web.Logic.Tests.Builders;
+
+public class EmailMessageBuilderTests
+{
+    private readonly List<Recipient> _to;
+    private readonly string _subject;
+    private readonly string _htmlBody;
+
+    private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
+
+    public EmailMessageBuilderTests()
+    {
+        _to = [new("john@doe.com", "John Doe")];
+        _subject = "Sample email";
+        _htmlBody = "Sample message";
+
+        var configurationSection = Substitute.For<IConfigurationSection>();
+        configurationSection.Value.Returns((string?)null);
+
+        _configuration
+            .GetSection(Arg.Any<string>())
+            .Returns(configurationSection);
+    }
+
+    [Fact]
+    public void ShouldThrowNullReferenceException_WhenEmailFromNotSet()
+    {
+        // Configuration will return null when trying to get the section Email:From
+        var emailMessageBuilder =
+            () => new EmailMessageBuilder(_configuration, _to, _subject, _htmlBody);
+
+        emailMessageBuilder.Should().Throw<NullReferenceException>()
+            .WithMessage("Email:From not set.");
+    }
+
+    [Fact]
+    public void ShouldOnlySet_SenderAddress_RecipientsTo_ContentsSubject_ContentsHtml_When_EmailFrom_IsSet_AndNoPropertyIsSetExplicitely()
+    {
+        // Arrange
+        var configurationSection = Substitute.For<IConfigurationSection>();
+        configurationSection.Value.Returns("from@email.com");
+
+        _configuration
+            .GetSection("Email:From")
+            .Returns(configurationSection);
+
+        var emailMessageBuilder = new EmailMessageBuilder(_configuration, _to, _subject, _htmlBody);
+
+        // Act
+        var emailMessage = emailMessageBuilder.Build();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            emailMessage.SenderAddress.Should().Be("from@email.com");
+
+            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
+            emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
+
+            emailMessage.Content.Subject.Should().Be("Sample email");
+
+            emailMessage.Content.Html.Should().Be("Sample message");
+
+            // The rest of the properties should be unset.
+            emailMessage.Content.PlainText.Should().BeNull();
+
+            emailMessage.Recipients.CC.Should().BeEmpty();
+            emailMessage.Recipients.BCC.Should().BeEmpty();
+            emailMessage.Headers.Should().BeEmpty();
+            emailMessage.ReplyTo.Should().BeEmpty();
+            emailMessage.Attachments.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public void ShouldSet_ReplyTo_WithDisplayNameSetToEmail_WhenOnly_EmailReplyToEmail_IsSet()
+    {
+        // Arrange
+        var configurationSectionEmailFrom = Substitute.For<IConfigurationSection>();
+        configurationSectionEmailFrom.Value.Returns("from@email.com");
+
+        _configuration
+            .GetSection("Email:From")
+            .Returns(configurationSectionEmailFrom);
+
+        var configurationSectionEmailReplyToEmail = Substitute.For<IConfigurationSection>();
+        configurationSectionEmailReplyToEmail.Value.Returns("reply-to@email.com");
+
+        _configuration
+            .GetSection("Email:ReplyToEmail")
+            .Returns(configurationSectionEmailReplyToEmail);
+
+        var emailMessageBuilder = new EmailMessageBuilder(_configuration, _to, _subject, _htmlBody);
+
+        // Act
+        var emailMessage = emailMessageBuilder.Build();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            emailMessage.SenderAddress.Should().Be("from@email.com");
+
+            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
+            emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
+
+            emailMessage.ReplyTo.Should().HaveCount(1);
+            emailMessage.ReplyTo.Single().Address.Should().Be("<reply-to@email.com>");
+            emailMessage.ReplyTo.Single().DisplayName.Should().Be("reply-to@email.com");
+
+            emailMessage.Content.Subject.Should().Be("Sample email");
+
+            emailMessage.Content.Html.Should().Be("Sample message");
+
+            // The rest of the properties should be unset.
+            emailMessage.Content.PlainText.Should().BeNull();
+
+            emailMessage.Recipients.CC.Should().BeEmpty();
+            emailMessage.Recipients.BCC.Should().BeEmpty();
+            emailMessage.Headers.Should().BeEmpty();
+            emailMessage.Attachments.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public void ShouldSet_ReplyTo_When_EmailReplyToEmail_EmailReplyToDisplayName_AreSet()
+    {
+        // Arrange
+        var configurationSectionEmailFrom = Substitute.For<IConfigurationSection>();
+        configurationSectionEmailFrom.Value.Returns("from@email.com");
+
+        _configuration
+            .GetSection("Email:From")
+            .Returns(configurationSectionEmailFrom);
+
+        var configurationSectionEmailReplyToEmail = Substitute.For<IConfigurationSection>();
+        configurationSectionEmailReplyToEmail.Value.Returns("reply-to@email.com");
+
+        _configuration
+            .GetSection("Email:ReplyToEmail")
+            .Returns(configurationSectionEmailReplyToEmail);
+
+        var configurationSectionEmailReplyToDisplayName = Substitute.For<IConfigurationSection>();
+        configurationSectionEmailReplyToDisplayName.Value.Returns("ReplyTo Display Name");
+
+        _configuration
+            .GetSection("Email:ReplyToDisplayName")
+            .Returns(configurationSectionEmailReplyToDisplayName);
+
+        var emailMessageBuilder = new EmailMessageBuilder(_configuration, _to, _subject, _htmlBody);
+
+        // Act
+        var emailMessage = emailMessageBuilder.Build();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            emailMessage.SenderAddress.Should().Be("from@email.com");
+
+            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
+            emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
+
+            emailMessage.ReplyTo.Should().HaveCount(1);
+            emailMessage.ReplyTo.Single().Address.Should().Be("<reply-to@email.com>");
+            emailMessage.ReplyTo.Single().DisplayName.Should().Be("\"ReplyTo Display Name\"");
+
+            emailMessage.Content.Subject.Should().Be("Sample email");
+
+            emailMessage.Content.Html.Should().Be("Sample message");
+
+            // The rest of the properties should be unset.
+            emailMessage.Content.PlainText.Should().BeNull();
+
+            emailMessage.Recipients.CC.Should().BeEmpty();
+            emailMessage.Recipients.BCC.Should().BeEmpty();
+            emailMessage.Headers.Should().BeEmpty();
+            emailMessage.Attachments.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public void ShouldSet_Recipients_Cc_Bcc_When_Cc_Bcc_AreSet()
+    {
+        // Arrange
+        var cc = new List<Recipient>
+            {
+                new("first-cc@email.com", "First Cc"),
+                new("second-cc@email.com")
+            };
+        var bcc = new List<Recipient>()
+            {
+                new("first-bcc@email.com"),
+                new("second-bcc@email.com", "Second Bcc")
+            };
+
+        var configurationSectionEmailFrom = Substitute.For<IConfigurationSection>();
+        configurationSectionEmailFrom.Value.Returns("from@email.com");
+
+        _configuration
+            .GetSection("Email:From")
+            .Returns(configurationSectionEmailFrom);
+
+        var emailMessageBuilder = new EmailMessageBuilder(_configuration, _to, _subject, _htmlBody);
+        emailMessageBuilder.Cc.AddRange(cc);
+        emailMessageBuilder.Bcc.AddRange(bcc);
+
+        // Act
+        var emailMessage = emailMessageBuilder.Build();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            emailMessage.SenderAddress.Should().Be("from@email.com");
+
+            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
+            emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
+
+            emailMessage.Recipients.CC.Should().HaveCount(2);
+            emailMessage.Recipients.CC[0].Address.Should().Be("<first-cc@email.com>");
+            emailMessage.Recipients.CC[0].DisplayName.Should().Be("\"First Cc\"");
+            emailMessage.Recipients.CC[1].Address.Should().Be("<second-cc@email.com>");
+            emailMessage.Recipients.CC[1].DisplayName.Should().Be("second-cc@email.com");
+
+            emailMessage.Recipients.BCC.Should().HaveCount(2);
+            emailMessage.Recipients.BCC[0].Address.Should().Be("<first-bcc@email.com>");
+            emailMessage.Recipients.BCC[0].DisplayName.Should().Be("first-bcc@email.com");
+            emailMessage.Recipients.BCC[1].Address.Should().Be("<second-bcc@email.com>");
+            emailMessage.Recipients.BCC[1].DisplayName.Should().Be("\"Second Bcc\"");
+
+            emailMessage.Content.Subject.Should().Be("Sample email");
+
+            emailMessage.Content.Html.Should().Be("Sample message");
+
+            // The rest of the properties should be unset.
+            emailMessage.Content.PlainText.Should().BeNull();
+
+            emailMessage.Headers.Should().BeEmpty();
+            emailMessage.ReplyTo.Should().BeEmpty();
+            emailMessage.Attachments.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public void ShouldSet_ContentsPlainText_When_BodyPlainText_IsSet()
+    {
+        // Arrange
+        var configurationSectionEmailFrom = Substitute.For<IConfigurationSection>();
+        configurationSectionEmailFrom.Value.Returns("from@email.com");
+
+        _configuration
+            .GetSection("Email:From")
+            .Returns(configurationSectionEmailFrom);
+
+        var emailMessageBuilder = new EmailMessageBuilder(_configuration, _to, _subject, _htmlBody)
+        {
+            BodyPlainText = "Message in plain text"
+        };
+
+        // Act
+        var emailMessage = emailMessageBuilder.Build();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            emailMessage.SenderAddress.Should().Be("from@email.com");
+
+            emailMessage.Recipients.To.Should().HaveCount(1);
+            emailMessage.Recipients.To.Single().Address.Should().Be("<john@doe.com>");
+            emailMessage.Recipients.To.Single().DisplayName.Should().Be("\"John Doe\"");
+
+            emailMessage.Content.Subject.Should().Be("Sample email");
+
+            emailMessage.Content.Html.Should().Be("Sample message");
+
+            emailMessage.Content.PlainText.Should().Be("Message in plain text");
+
+            // The rest of the properties should be unset.
+            emailMessage.Recipients.CC.Should().BeEmpty();
+            emailMessage.Recipients.BCC.Should().BeEmpty();
+            emailMessage.Headers.Should().BeEmpty();
+            emailMessage.ReplyTo.Should().BeEmpty();
+            emailMessage.Attachments.Should().BeEmpty();
+        }
+    }
+}

--- a/test/Fonbec.Web.Logic.Tests/Fonbec.Web.Logic.Tests.csproj
+++ b/test/Fonbec.Web.Logic.Tests/Fonbec.Web.Logic.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="8.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/test/Fonbec.Web.Logic.Tests/Models/RecipientTests.cs
+++ b/test/Fonbec.Web.Logic.Tests/Models/RecipientTests.cs
@@ -1,0 +1,32 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using Fonbec.Web.Logic.Models;
+
+namespace Fonbec.Web.Logic.Tests.Models;
+
+public class RecipientTests
+{
+    [Fact]
+    public void ShouldUseEmailAddressForDisplayName_WhenCtorCalledWithEmailOnly()
+    {
+        var sut = new Recipient("john@doe.com");
+
+        using (new AssertionScope())
+        {
+            sut.DisplayName.Should().Be("john@doe.com");
+            sut.EmailAddress.Should().Be("<john@doe.com>");
+        }
+    }
+
+    [Fact]
+    public void ShouldNotUseEmailAddressForDisplayName_WhenCtorCalledWithEmailAndDisplayName()
+    {
+        var sut = new Recipient("john@doe.com", "John Doe");
+
+        using (new AssertionScope())
+        {
+            sut.DisplayName.Should().Be("\"John Doe\"");
+            sut.EmailAddress.Should().Be("<john@doe.com>");
+        }
+    }
+}


### PR DESCRIPTION
[AB#8](https://dev.azure.com/fonbec/7c886795-fbb9-47d1-8b02-091ee7ebf55a/_workitems/edit/8)

- Register Identity's `IEmailSender` to send emails using Communication Services
- Unit test services

References:
- [Send an email using Azure Communication Services](https://learn.microsoft.com/en-us/azure/communication-services/quickstarts/email/send-email?tabs=windows&pivots=programming-language-csharp)