### PR TITLE
AB#29 Display and Filter User Roles in the Users List

### DIFF
--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UsersList.razor
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UsersList.razor
@@ -21,7 +21,7 @@
                  EditTrigger="DataGridEditTrigger.Manual"
                  QuickFilter="Filter"
                  Filterable="true"
-                 FilterMode="DataGridFilterMode.ColumnFilterMenu"
+                 FilterMode="DataGridFilterMode.ColumnFilterRow"
                  FilterCaseSensitivity="DataGridFilterCaseSensitivity.CaseInsensitive"
                  SortMode="SortMode.Multiple"
                  Class="mt-4">
@@ -32,7 +32,26 @@
                           Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" />
         </ToolBarContent>
         <Columns>
-            <PropertyColumn Property="@(x => $"{x.UserFirstName} {x.UserLastName}")" Title="Nombre">
+            <PropertyColumn Property="@(x => _sortByLastName ? x.UserLastName : x.UserFirstName)" Title="Nombre">
+                <CellTemplate>
+                    <MudText Typo="Typo.body1">
+                        @if (_sortByLastName)
+                        {
+                            <span>@context.Item.UserLastName, @context.Item.UserFirstName</span>
+                        }
+                        else
+                        {
+                            <span>@context.Item.UserFirstName @context.Item.UserLastName</span>
+                        }
+
+                        @if (context.Item.UserId == _userId)
+                        {
+                            <MudChip Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" Class="ml-3">
+                                YO
+                            </MudChip>
+                        }
+                    </MudText>
+                </CellTemplate>
                 <EditTemplate>
                     <MudTextField T="string" @bind-Value="@context.Item.UserFirstName" Immediate="true"
                                   Required="true" RequiredError="Este es un campo requerido"
@@ -43,6 +62,52 @@
                                   Label="Apellido" Variant="Variant.Outlined" Margin="Margin.Dense"
                                   MaxLength="MaxLength.FonbecWebUser.FirstName" />
                 </EditTemplate>
+            </PropertyColumn>
+            <PropertyColumn Property="x => x.Roles.FirstOrDefault()" Title="Roles">
+                <CellTemplate>
+                    @foreach (var role in context.Item.Roles)
+                    {
+                        var color = role switch
+                        {
+                            FonbecRole.Admin => Color.Secondary,
+                            FonbecRole.Manager => Color.Warning,
+                            FonbecRole.Uploader => Color.Info,
+                            FonbecRole.Reviewer => Color.Primary,
+                            _ => Color.Default
+                        };
+                        <MudChip Variant="Variant.Outlined" Color="@color">
+                            @role
+                        </MudChip>
+                    }
+                </CellTemplate>
+                <EditTemplate>
+                </EditTemplate>
+                <FilterTemplate>
+                    <MudIconButton OnClick="@(() => _isRolesFilterOpen = true)" Icon="@_rolesFilterIcon" Size="@Size.Small" />
+                    <MudOverlay OnClick="@(() => _isRolesFilterOpen = false)" Visible="@_isRolesFilterOpen" />
+                    <MudPopover Open="@_isRolesFilterOpen" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter"
+                                Style="width:200px">
+                        <MudStack Spacing="0">
+                            <MudCheckBox T="bool" Label="Seleccionar todos" Size="@Size.Small" Value="@_areAllRolesSelected" ValueChanged="OnSelectAllRolesChanged" />
+                            <MudStack Spacing="0" Style="overflow-y:auto;max-height:250px">
+                                @foreach (var role in FonbecRole.AllRoles)
+                                {
+                                    <MudCheckBox T="bool" Label="@role" Size="@Size.Small"
+                                                 Value="@(_selectedRoles.Contains(role))"
+                                                 ValueChanged="@(isSelected => SelectedChanged(role, isSelected))" />
+                                }
+                            </MudStack>
+                            <MudStack Row="true" Class="d-flex justify-space-between ma-2">
+                                <MudButton OnClick="@(() => ClearFilterAsync(context))" Color="Color.Default">
+                                    Limpiar
+                                </MudButton>
+                                <MudButton OnClick="@(() => ApplyFilterAsync(context))" Color="Color.Primary" Variant="Variant.Filled">
+                                    Filtrar
+                                </MudButton>
+                            </MudStack>
+                        </MudStack>
+                    </MudPopover>
+                </FilterTemplate>
             </PropertyColumn>
             <PropertyColumn Property="x => x.UserNickName" Title="Apodo" Hidden="true" Required="false" />
             <PropertyColumn Property="x => x.UserGender" Title="Sexo" Hidden="true">
@@ -56,7 +121,7 @@
             </PropertyColumn>
             <PropertyColumn Property="x => x.UserEmail" Title="Correo electrónico">
                 <CellTemplate>
-                    <MudLink Href="@($"mailto:{context.Item.UserEmail}")" Typo="Typo.body2">
+                    <MudLink Href="@($"mailto:{context.Item.UserEmail}")">
                         @context.Item.UserEmail
                     </MudLink>
                 </CellTemplate>
@@ -90,4 +155,8 @@
             <MudDataGridPager T="AllUsersViewModel" RowsPerPageString="Filas por página:" InfoFormat="{first_item}-{last_item} of {all_items}" />
         </PagerContent>
     </MudDataGrid>
+
+    <MudSwitch @bind-Value="_sortByLastName">
+        @(_sortByLastName ? "Ordenar por apellido" : "Ordenar por nombre")
+    </MudSwitch>
 }

--- a/src/2-Logic/Fonbec.Web.Logic/Models/Users/AllUsersViewModel.cs
+++ b/src/2-Logic/Fonbec.Web.Logic/Models/Users/AllUsersViewModel.cs
@@ -20,6 +20,8 @@ public class AllUsersViewModel
 
     public string UserPhoneNumber { get; set; } = null!;
 
+    public IEnumerable<string> Roles { get; set; } = null!;
+
     public bool IsUserActive { get; set; }
 }
 
@@ -27,7 +29,7 @@ public class AllUsersViewModelMappingDefinitions : IRegister
 {
     public void Register(TypeAdapterConfig config)
     {
-        config.NewConfig<AllUsersDataModel, AllUsersViewModel>()
+        config.NewConfig<AllUsersUserDataModel, AllUsersViewModel>()
             .Map(dest => dest.UserId, src => src.UserId)
             .Map(dest => dest.UserFirstName, src => src.UserFirstName)
             .Map(dest => dest.UserLastName, src => src.UserLastName)

--- a/src/3-DataAccess/Fonbec.Web.DataAccess/DataModels/Users/AllUsersDataModel.cs
+++ b/src/3-DataAccess/Fonbec.Web.DataAccess/DataModels/Users/AllUsersDataModel.cs
@@ -4,6 +4,13 @@ namespace Fonbec.Web.DataAccess.DataModels.Users;
 
 public class AllUsersDataModel
 {
+    public List<AllUsersUserDataModel> Users { get; set; } = null!;
+
+    public List<AllUsersUsersInRolesDataModel> UsersInRoles { get; set; } = new();
+}
+
+public class AllUsersUserDataModel
+{
     public int UserId { get; set; }
 
     public string UserFirstName { get; set; } = null!;
@@ -21,4 +28,11 @@ public class AllUsersDataModel
     public bool IsUserLockedOut { get; set; }
 
     public DateTimeOffset? UserLockOutEndsOnUtc { get; set; }
+}
+
+public class AllUsersUsersInRolesDataModel
+{
+    public string Role { get; set; } = null!;
+
+    public IEnumerable<int> UserIdsInRole { get; set; } = null!;
 }

--- a/src/3-DataAccess/Fonbec.Web.DataAccess/Repositories/UserRepository.cs
+++ b/src/3-DataAccess/Fonbec.Web.DataAccess/Repositories/UserRepository.cs
@@ -1,4 +1,5 @@
-﻿using Fonbec.Web.DataAccess.DataModels.Users;
+﻿using Fonbec.Web.DataAccess.Constants;
+using Fonbec.Web.DataAccess.DataModels.Users;
 using Fonbec.Web.DataAccess.DataModels.Users.Input;
 using Fonbec.Web.DataAccess.Entities;
 using Microsoft.AspNetCore.Identity;
@@ -8,17 +9,19 @@ namespace Fonbec.Web.DataAccess.Repositories;
 
 public interface IUserRepository
 {
-    Task<List<AllUsersDataModel>> GetAllUsersAsync();
-    Task<IdentityResult> UpdateUserAsync(UpdateUserInputDataModel model);
+    Task<AllUsersDataModel> GetAllUsersAsync();
+    Task<bool> UpdateUserAsync(UpdateUserInputDataModel model);
 }
 
 public class UserRepository(UserManager<FonbecWebUser> userManager) : IUserRepository
 {
-    public async Task<List<AllUsersDataModel>> GetAllUsersAsync()
+    public async Task<AllUsersDataModel> GetAllUsersAsync()
     {
-        var allUsers = await userManager.Users
+        var result = new AllUsersDataModel();
+
+        var users = await userManager.Users
             .Select(u =>
-                new AllUsersDataModel
+                new AllUsersUserDataModel
                 {
                     UserId = u.Id,
                     UserFirstName = u.FirstName,
@@ -30,27 +33,52 @@ public class UserRepository(UserManager<FonbecWebUser> userManager) : IUserRepos
                     IsUserLockedOut = u.LockoutEnabled,
                     UserLockOutEndsOnUtc = u.LockoutEnd,
                 })
+            .OrderBy(dm => dm.UserFirstName)
             .ToListAsync();
 
-        return allUsers;
+        result.Users = users;
+
+        foreach (var role in FonbecRole.AllRoles)
+        {
+            var usersInRole = await userManager.GetUsersInRoleAsync(role);
+
+            var usersInRoles = new AllUsersUsersInRolesDataModel
+            {
+                Role = role,
+                UserIdsInRole = usersInRole.Select(u => u.Id),
+            };
+
+            result.UsersInRoles.Add(usersInRoles);
+        }
+
+        return result;
     }
 
-    public async Task<IdentityResult> UpdateUserAsync(UpdateUserInputDataModel model)
+    public async Task<bool> UpdateUserAsync(UpdateUserInputDataModel model)
     {
         var fonbecUserDb = await userManager.FindByIdAsync(model.UserId);
         if (fonbecUserDb is null)
         {
-            return IdentityResult.Failed();
+            return false;
+        }
+
+        var oldEmail = fonbecUserDb.Email;
+        var newEmail = model.UserEmail;
+        
+        if (oldEmail != newEmail)
+        {
+            // Update both user name and email address
+            fonbecUserDb.UserName = newEmail;
+            fonbecUserDb.Email = newEmail;
         }
 
         fonbecUserDb.FirstName = model.UserFirstName;
         fonbecUserDb.LastName = model.UserLastName;
         fonbecUserDb.NickName = model.UserNickName;
         fonbecUserDb.Gender = model.Gender;
-        fonbecUserDb.Email = model.UserEmail;
         fonbecUserDb.PhoneNumber = model.UserPhoneNumber;
 
         var identityResult = await userManager.UpdateAsync(fonbecUserDb);
-        return identityResult;
+        return identityResult.Succeeded;
     }
 }

--- a/test/Fonbec.Web.Logic.Tests/Models/Users/AllUsersViewModelMappingDefinitionsTests.cs
+++ b/test/Fonbec.Web.Logic.Tests/Models/Users/AllUsersViewModelMappingDefinitionsTests.cs
@@ -3,7 +3,6 @@ using Fonbec.Web.DataAccess.DataModels.Users;
 using Fonbec.Web.DataAccess.Entities.Enums;
 using Fonbec.Web.Logic.Models.Users;
 using Mapster;
-using System.Data;
 
 namespace Fonbec.Web.Logic.Tests.Models.Users;
 
@@ -12,14 +11,15 @@ namespace Fonbec.Web.Logic.Tests.Models.Users;
 /// - All fields mapped directly.
 /// - Null handling for UserNickName, UserEmail, and UserPhoneNumber.
 /// - Both branches for IsUserActive logic.
+/// - Roles property default value.
 /// </summary>
 public class AllUsersViewModelMappingDefinitionsTests : MappingTestBase
 {
     [Fact]
-    public void Maps_User_From_DataModel_To_ViewModel()
+    public void Maps_User_From_UserDataModel_To_ViewModel()
     {
         var now = DateTimeOffset.Now;
-        var dataModel = new AllUsersDataModel
+        var userDataModel = new AllUsersUserDataModel
         {
             UserId = 1,
             UserFirstName = "John",
@@ -32,7 +32,7 @@ public class AllUsersViewModelMappingDefinitionsTests : MappingTestBase
             UserLockOutEndsOnUtc = now.AddMinutes(-1)
         };
 
-        var viewModel = dataModel.Adapt<AllUsersViewModel>(Config);
+        var viewModel = userDataModel.Adapt<AllUsersViewModel>(Config);
 
         viewModel.UserId.Should().Be(1);
         viewModel.UserFirstName.Should().Be("John");
@@ -42,18 +42,19 @@ public class AllUsersViewModelMappingDefinitionsTests : MappingTestBase
         viewModel.UserEmail.Should().Be("john.doe@example.com");
         viewModel.UserPhoneNumber.Should().Be("1234567890");
         viewModel.IsUserActive.Should().BeTrue();
+        viewModel.Roles.Should().BeNull(); // Not mapped by default
     }
 
     [Fact]
     public void Sets_UserNickName_Empty_When_Null()
     {
-        var dataModel = new AllUsersDataModel
+        var userDataModel = new AllUsersUserDataModel
         {
             UserNickName = null,
             UserLockOutEndsOnUtc = null
         };
 
-        var viewModel = dataModel.Adapt<AllUsersViewModel>(Config);
+        var viewModel = userDataModel.Adapt<AllUsersViewModel>(Config);
 
         viewModel.UserNickName.Should().BeEmpty();
     }
@@ -61,13 +62,13 @@ public class AllUsersViewModelMappingDefinitionsTests : MappingTestBase
     [Fact]
     public void Sets_UserEmail_Empty_When_Null()
     {
-        var dataModel = new AllUsersDataModel
+        var userDataModel = new AllUsersUserDataModel
         {
             UserEmail = null,
             UserLockOutEndsOnUtc = null
         };
 
-        var viewModel = dataModel.Adapt<AllUsersViewModel>(Config);
+        var viewModel = userDataModel.Adapt<AllUsersViewModel>(Config);
 
         viewModel.UserEmail.Should().BeEmpty();
     }
@@ -75,13 +76,13 @@ public class AllUsersViewModelMappingDefinitionsTests : MappingTestBase
     [Fact]
     public void Sets_UserPhoneNumber_Empty_When_Null()
     {
-        var dataModel = new AllUsersDataModel
+        var userDataModel = new AllUsersUserDataModel
         {
             UserPhoneNumber = null,
             UserLockOutEndsOnUtc = null
         };
 
-        var viewModel = dataModel.Adapt<AllUsersViewModel>(Config);
+        var viewModel = userDataModel.Adapt<AllUsersViewModel>(Config);
 
         viewModel.UserPhoneNumber.Should().BeEmpty();
     }
@@ -89,13 +90,13 @@ public class AllUsersViewModelMappingDefinitionsTests : MappingTestBase
     [Fact]
     public void IsUserActive_True_When_NotLockedOut_And_LockoutEndsInPast()
     {
-        var dataModel = new AllUsersDataModel
+        var userDataModel = new AllUsersUserDataModel
         {
             IsUserLockedOut = false,
             UserLockOutEndsOnUtc = DateTimeOffset.Now.AddMinutes(-5)
         };
 
-        var viewModel = dataModel.Adapt<AllUsersViewModel>(Config);
+        var viewModel = userDataModel.Adapt<AllUsersViewModel>(Config);
 
         viewModel.IsUserActive.Should().BeTrue();
     }
@@ -103,13 +104,13 @@ public class AllUsersViewModelMappingDefinitionsTests : MappingTestBase
     [Fact]
     public void IsUserActive_False_When_LockedOut()
     {
-        var dataModel = new AllUsersDataModel
+        var userDataModel = new AllUsersUserDataModel
         {
             IsUserLockedOut = true,
             UserLockOutEndsOnUtc = DateTimeOffset.Now.AddMinutes(-5)
         };
 
-        var viewModel = dataModel.Adapt<AllUsersViewModel>(Config);
+        var viewModel = userDataModel.Adapt<AllUsersViewModel>(Config);
 
         viewModel.IsUserActive.Should().BeFalse();
     }
@@ -117,13 +118,13 @@ public class AllUsersViewModelMappingDefinitionsTests : MappingTestBase
     [Fact]
     public void IsUserActive_True_When_LockoutEndsOnUtc_Is_Null_And_NotLockedOut()
     {
-        var dataModel = new AllUsersDataModel
+        var userDataModel = new AllUsersUserDataModel
         {
             IsUserLockedOut = false,
             UserLockOutEndsOnUtc = null
         };
 
-        var viewModel = dataModel.Adapt<AllUsersViewModel>(Config);
+        var viewModel = userDataModel.Adapt<AllUsersViewModel>(Config);
 
         viewModel.IsUserActive.Should().BeTrue();
     }
@@ -131,13 +132,13 @@ public class AllUsersViewModelMappingDefinitionsTests : MappingTestBase
     [Fact]
     public void IsUserActive_False_When_LockoutEndsOnUtc_Is_Null_And_LockedOut()
     {
-        var dataModel = new AllUsersDataModel
+        var userDataModel = new AllUsersUserDataModel
         {
             IsUserLockedOut = true,
             UserLockOutEndsOnUtc = null
         };
 
-        var viewModel = dataModel.Adapt<AllUsersViewModel>(Config);
+        var viewModel = userDataModel.Adapt<AllUsersViewModel>(Config);
 
         viewModel.IsUserActive.Should().BeFalse();
     }


### PR DESCRIPTION
[AB#29](https://dev.azure.com/fonbec/7c886795-fbb9-47d1-8b02-091ee7ebf55a/_workitems/edit/29)

- Load user Roles + fIlter by Roles
- Display "YOU" next to currently logged-in user
- Allow to sort by first name or last name
- Prevent Roles from being editable in the data grid's edit dialog
- Update user name when updating email address
  - IMPORTANT: this is a simple implementation that doesn't notify the user of the change; it is assumed that the person with rights to edit users knows what they are doing!