### PR TITLE
AB#44 Implement Fine-Grained Page-Level Authorization and User Permissions Management

### DIFF
--- a/src/1-UI/Fonbec.Web.Ui/Authorization/FonbecPermissionHandler.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Authorization/FonbecPermissionHandler.cs
@@ -1,0 +1,26 @@
+﻿using Fonbec.Web.Logic.Services;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Fonbec.Web.Ui.Authorization;
+
+internal class FonbecPermissionHandler(IUserService userService) : AuthorizationHandler<FonbecPermissionRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, FonbecPermissionRequirement requirement)
+    {
+        var fonbecAuthValue = userService.GetFonbecAuthClaim(context.User);
+
+        if (fonbecAuthValue is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var hasPermission = userService.HasPermission(fonbecAuthValue, requirement.PageName);
+
+        if (hasPermission)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/1-UI/Fonbec.Web.Ui/Authorization/FonbecPermissionRequirement.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Authorization/FonbecPermissionRequirement.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Fonbec.Web.Ui.Authorization;
+
+internal class FonbecPermissionRequirement(string pageName) : IAuthorizationRequirement
+{
+    public string PageName { get; } = pageName;
+}

--- a/src/1-UI/Fonbec.Web.Ui/Authorization/PageAccessDiscovery.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Authorization/PageAccessDiscovery.cs
@@ -1,0 +1,25 @@
+﻿using Fonbec.Web.Ui.Components;
+using Fonbec.Web.Ui.Components.Pages;
+using Microsoft.AspNetCore.Components;
+using System.Reflection;
+
+namespace Fonbec.Web.Ui.Authorization;
+
+public static class PageAccessDiscovery
+{
+    public static List<PageAccessInfo> DiscoverPages()
+    {
+        // Find all components in the assembly that have the PageMetadataAttribute
+        var pageMetadataAttributes = typeof(App).Assembly.ExportedTypes
+            .Where(type => typeof(IComponent).IsAssignableFrom(type))
+            .Select(type => type.GetCustomAttribute<PageMetadataAttribute>(false))
+            .Where(pageMetadata => pageMetadata is not null);
+
+        var results = pageMetadataAttributes.Select(pageMetadata =>
+            new PageAccessInfo(pageMetadata!.Codename, pageMetadata.Description))
+            .OrderBy(pai => pai.Codename)
+            .ToList();
+
+        return results;
+    }
+}

--- a/src/1-UI/Fonbec.Web.Ui/Authorization/PageAccessDiscovery.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Authorization/PageAccessDiscovery.cs
@@ -2,6 +2,7 @@
 using Fonbec.Web.Ui.Components.Pages;
 using Microsoft.AspNetCore.Components;
 using System.Reflection;
+using Fonbec.Web.Logic.Authorization;
 
 namespace Fonbec.Web.Ui.Authorization;
 
@@ -16,7 +17,9 @@ public static class PageAccessDiscovery
             .Where(pageMetadata => pageMetadata is not null);
 
         var results = pageMetadataAttributes.Select(pageMetadata =>
-            new PageAccessInfo(pageMetadata!.Codename, pageMetadata.Description))
+            new PageAccessInfo(pageMetadata!.Codename,
+                pageMetadata.Description,
+                pageMetadata.Roles))
             .OrderBy(pai => pai.Codename)
             .ToList();
 

--- a/src/1-UI/Fonbec.Web.Ui/Authorization/PageAccessInfo.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Authorization/PageAccessInfo.cs
@@ -1,3 +1,0 @@
-﻿namespace Fonbec.Web.Ui.Authorization;
-
-public record PageAccessInfo(string Codename, string Description);

--- a/src/1-UI/Fonbec.Web.Ui/Authorization/PageAccessInfo.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Authorization/PageAccessInfo.cs
@@ -1,0 +1,3 @@
+﻿namespace Fonbec.Web.Ui.Authorization;
+
+public record PageAccessInfo(string Codename, string Description);

--- a/src/1-UI/Fonbec.Web.Ui/Components/Layout/NavMenu.razor
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Layout/NavMenu.razor
@@ -2,23 +2,33 @@
 
 @inject NavigationManager NavigationManager
 
+@using Fonbec.Web.Ui.Components.Pages.Chapters
+@using Fonbec.Web.Ui.Components.Pages.Students
+@using Fonbec.Web.Ui.Components.Pages.Users
+
 <MudNavMenu>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
 
-    <AuthorizeView>
-        <Authorized>
-            <MudNavLink Href="@NavRoutes.Chapters" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Place">Filiales</MudNavLink>
-            <MudNavLink Href="@NavRoutes.Users" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.AccountBox">Usuarios</MudNavLink>
-            <MudNavLink Href="@NavRoutes.Students" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Face">Becarios</MudNavLink>
-            <MudNavLink Href="Account/Manage" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Person">@context.User.Identity?.Name</MudNavLink>
-            <form action="Account/Logout" method="post">
-                <AntiforgeryToken />
-                <input type="hidden" name="ReturnUrl" value="@_currentUrl" />
-                <button type="submit" class="mud-nav-link mud-ripple">
-                    <MudIcon Icon="@Icons.Material.Filled.Logout" Color="Color.Info" Class="mr-3"></MudIcon> Logout
-                </button>
-            </form>
-        </Authorized>
+    <AuthorizeView Context="outerContext">
+	    <Authorized>
+		    <AuthorizeView Policy="@nameof(ChaptersList)">
+				<MudNavLink Href="@NavRoutes.Chapters" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Place">Filiales</MudNavLink>
+            </AuthorizeView>
+		    <AuthorizeView Policy="@nameof(UsersList)">
+			    <MudNavLink Href="@NavRoutes.Users" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.AccountBox">Usuarios</MudNavLink>
+		    </AuthorizeView>
+		    <AuthorizeView Policy="@nameof(StudentsList)">
+				<MudNavLink Href="@NavRoutes.Students" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Face">Becarios</MudNavLink>
+		    </AuthorizeView>
+		    <MudNavLink Href="Account/Manage" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Person">@outerContext.User.Identity?.Name</MudNavLink>
+		    <form action="Account/Logout" method="post">
+			    <AntiforgeryToken />
+			    <input type="hidden" name="ReturnUrl" value="@_currentUrl" />
+			    <button type="submit" class="mud-nav-link mud-ripple">
+				    <MudIcon Icon="@Icons.Material.Filled.Logout" Color="Color.Info" Class="mr-3"></MudIcon> Logout
+			    </button>
+		    </form>
+	    </Authorized>
         <NotAuthorized>
             <MudNavLink Href="/Account/Login" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Password">Login</MudNavLink>
         </NotAuthorized>

--- a/src/1-UI/Fonbec.Web.Ui/Components/NonPages/FilterByList.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/NonPages/FilterByList.razor.cs
@@ -8,12 +8,12 @@ public partial class FilterByList<T>
     private string _filterIcon = Icons.Material.Outlined.FilterAlt;
     private bool _isFilterOpen;
     private bool _areAllItemsSelected = true;
-    private HashSet<string> _selectedItems = new();
-    private HashSet<string> _selectedItemsBeforeFilter = new();
+    private HashSet<string> _selectedItems = [];
+    private HashSet<string> _selectedItemsBeforeFilter = [];
     private FilterDefinition<T> _filterItemsDefinition = null!;
 
     [Parameter, EditorRequired]
-    public string[] AllItems { get; set; } = null!;
+    public IEnumerable<string> AllItems { get; set; } = null!;
 
     [Parameter, EditorRequired]
     public FilterContext<T> FilterContext { get; set; } = null!;
@@ -61,7 +61,7 @@ public partial class FilterByList<T>
             _selectedItems.Remove(chapter);
         }
 
-        _areAllItemsSelected = _selectedItems.Count == AllItems.Length;
+        _areAllItemsSelected = _selectedItems.Count == AllItems.Count();
     }
 
     private async Task ClearItemsFilterAsync(FilterContext<T> context)
@@ -77,7 +77,7 @@ public partial class FilterByList<T>
     private async Task ApplyItemsFilterAsync(FilterContext<T> context)
     {
         _selectedItemsBeforeFilter = _selectedItems.ToHashSet();
-        _filterIcon = _selectedItemsBeforeFilter.Count == AllItems.Length
+        _filterIcon = _selectedItemsBeforeFilter.Count == AllItems.Count()
             ? Icons.Material.Outlined.FilterAlt
             : Icons.Material.Filled.FilterAlt;
         await context.Actions.ApplyFilterAsync(_filterItemsDefinition);

--- a/src/1-UI/Fonbec.Web.Ui/Components/NonPages/Selectors/FacilitatorSelector.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/NonPages/Selectors/FacilitatorSelector.razor.cs
@@ -9,7 +9,7 @@ public partial class FacilitatorSelector
 {
     private bool _dataLoaded;
 
-    private readonly List<SelectableModel<int>> _facilitators = new();
+    private readonly List<SelectableModel<int>> _facilitators = [];
 
     private SelectableModel<int> _selectedFacilitator = null!;
 

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/ChaptersList.razor
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/ChaptersList.razor
@@ -1,5 +1,5 @@
 ﻿@attribute [Route(NavRoutes.Chapters)]
-@attribute [Authorize]
+@attribute [Authorize(Policy = nameof(ChaptersList))]
 
 <PageTitle>Filiales</PageTitle>
 
@@ -19,4 +19,6 @@
     </RowTemplate>
 </MudTable>
 
-<CreateChapter OnChapterCreated="RefreshChapters"/>
+<AuthorizeView Policy="@nameof(CreateChapter)">
+	<CreateChapter OnChapterCreated="RefreshChapters"/>
+</AuthorizeView>

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/ChaptersList.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/ChaptersList.razor.cs
@@ -1,10 +1,11 @@
-﻿using Fonbec.Web.Logic.Models.Chapters;
+﻿using Fonbec.Web.DataAccess.Constants;
+using Fonbec.Web.Logic.Models.Chapters;
 using Fonbec.Web.Logic.Services;
 using Microsoft.AspNetCore.Components;
 
 namespace Fonbec.Web.Ui.Components.Pages.Chapters;
 
-[PageMetadata(nameof(ChaptersList), "Lista de filiales")]
+[PageMetadata(nameof(ChaptersList), "Lista de filiales", [FonbecRole.Admin])]
 public partial class ChaptersList
 {
     private List<ChaptersListViewModel> _viewModel = [];

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/ChaptersList.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/ChaptersList.razor.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Fonbec.Web.Ui.Components.Pages.Chapters;
 
+[PageMetadata(nameof(ChaptersList), "Lista de filiales")]
 public partial class ChaptersList
 {
     private List<ChaptersListViewModel> _viewModel = [];

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/CreateChapter.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/CreateChapter.razor.cs
@@ -5,16 +5,17 @@ using Fonbec.Web.Logic.Services;
 
 namespace Fonbec.Web.Ui.Components.Pages.Chapters;
 
+[PageMetadata(nameof(CreateChapter), "Crear filial")]
 public partial class CreateChapter : AuthenticationRequiredComponentBase
 {
     private MudForm? _form;
     private string? _name;
 
-    [Inject]
-    public IChapterService ChapterService { get; set; } = null!;
-
     [Parameter]
     public EventCallback OnChapterCreated { get; set; }
+
+    [Inject]
+    public IChapterService ChapterService { get; set; } = null!;
 
     private bool IsCreateButtonDisabled => string.IsNullOrWhiteSpace(_name);
 
@@ -25,8 +26,7 @@ public partial class CreateChapter : AuthenticationRequiredComponentBase
             return;
         }
 
-        var userId = await GetAuthenticatedUserIdAsync();
-        var inputModel = new CreateChapterInputModel(_name, userId);
+        var inputModel = new CreateChapterInputModel(_name, CurrentUserId);
         await ChapterService.CreateChapterAsync(inputModel);
         await OnChapterCreated.InvokeAsync(); // Notufy parent component (ChaptersList)
         _name = string.Empty;

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/CreateChapter.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Chapters/CreateChapter.razor.cs
@@ -1,11 +1,12 @@
-﻿using MudBlazor;
-using Microsoft.AspNetCore.Components;
+﻿using Fonbec.Web.DataAccess.Constants;
 using Fonbec.Web.Logic.Models.Chapters.Input;
 using Fonbec.Web.Logic.Services;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
 
 namespace Fonbec.Web.Ui.Components.Pages.Chapters;
 
-[PageMetadata(nameof(CreateChapter), "Crear filial")]
+[PageMetadata(nameof(CreateChapter), "Crear filial", [FonbecRole.Admin])]
 public partial class CreateChapter : AuthenticationRequiredComponentBase
 {
     private MudForm? _form;

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/PageMetadataAttribute.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/PageMetadataAttribute.cs
@@ -1,9 +1,11 @@
 ﻿namespace Fonbec.Web.Ui.Components.Pages;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class PageMetadataAttribute(string codename, string description) : Attribute
+public class PageMetadataAttribute(string codename, string description, string[] roles) : Attribute
 {
     public string Codename { get; } = codename;
 
     public string Description { get; } = description;
+
+    public string[] Roles { get; set; } = roles;
 }

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/PageMetadataAttribute.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/PageMetadataAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace Fonbec.Web.Ui.Components.Pages;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class PageMetadataAttribute(string codename, string description) : Attribute
+{
+    public string Codename { get; } = codename;
+
+    public string Description { get; } = description;
+}

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentCreate.razor
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentCreate.razor
@@ -1,4 +1,5 @@
 ﻿@attribute [Route(NavRoutes.StudentCreate)]
+@attribute [Authorize(Policy = nameof(StudentCreate))]
 @inherits AuthenticationRequiredComponentBase
 
 @using Fonbec.Web.DataAccess.Constants

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentCreate.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentCreate.razor.cs
@@ -1,4 +1,5 @@
-﻿using Fonbec.Web.Logic.Models.Students.Input;
+﻿using Fonbec.Web.DataAccess.Constants;
+using Fonbec.Web.Logic.Models.Students.Input;
 using Fonbec.Web.Logic.Services;
 using Fonbec.Web.Ui.Constants;
 using Fonbec.Web.Ui.Models.Student;
@@ -7,7 +8,7 @@ using MudBlazor;
 
 namespace Fonbec.Web.Ui.Components.Pages.Students;
 
-[PageMetadata(nameof(StudentCreate), "Alta y modificación de becario")]
+[PageMetadata(nameof(StudentCreate), "Crear y actualizar becario", [FonbecRole.Manager])]
 public partial class StudentCreate : AuthenticationRequiredComponentBase
 {
     private readonly StudentCreateBindModel _bindModel = new();

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentCreate.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentCreate.razor.cs
@@ -7,6 +7,7 @@ using MudBlazor;
 
 namespace Fonbec.Web.Ui.Components.Pages.Students;
 
+[PageMetadata(nameof(StudentCreate), "Alta y modificación de becario")]
 public partial class StudentCreate : AuthenticationRequiredComponentBase
 {
     private readonly StudentCreateBindModel _bindModel = new();
@@ -41,8 +42,6 @@ public partial class StudentCreate : AuthenticationRequiredComponentBase
     {
         _saving = true;
 
-        var userId = await GetAuthenticatedUserIdAsync();
-
         var createStudentInputModel = new CreateStudentInputModel(
             _bindModel.ChapterId,
             _bindModel.StudentFirstName,
@@ -55,7 +54,7 @@ public partial class StudentCreate : AuthenticationRequiredComponentBase
             _bindModel.StudentSecondarySchoolStartYear,
             _bindModel.StudentUniversityStartYear,
             _bindModel.FacilitatorId,
-            userId);
+            CurrentUserId);
 
         var result = await StudentService.CreateStudentAsync(createStudentInputModel);
         if (!result.AnyAffectedRows)

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentsList.razor
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentsList.razor
@@ -1,4 +1,5 @@
 ﻿@attribute [Route(NavRoutes.Students)]
+@attribute [Authorize(Policy = nameof(StudentsList))]
 @inherits AuthenticationRequiredComponentBase
 
 @using Fonbec.Web.DataAccess.Constants
@@ -8,13 +9,15 @@
 <PageHeader Title="Becarios" />
 
 <MudStack StretchItems="StretchItems.Middle" Row="true">
-	<MudTooltip Text="Alta de becario"
-	            Arrow="true" Placement="Placement.Right"
-	            Color="Color.Primary">
-		<MudFab Href="@NavRoutes.StudentCreate"
-		        StartIcon="@Icons.Material.Filled.Add"
-		        Color="Color.Primary" />
-	</MudTooltip>
+	<AuthorizeView Policy="@nameof(StudentCreate)">
+		<MudTooltip Text="Alta de becario"
+		            Arrow="true" Placement="Placement.Right"
+		            Color="Color.Primary">
+			<MudFab Href="@NavRoutes.StudentCreate"
+			        StartIcon="@Icons.Material.Filled.Add"
+			        Color="Color.Primary" />
+		</MudTooltip>
+	</AuthorizeView>
 	<MudSpacer />
 	<MudSwitch @bind-Value="_sortByLastName" LabelPlacement="Placement.Left">
 		@(_sortByLastName ? "Apellido, Nombre" : "Nombre Apellido")
@@ -136,11 +139,13 @@
 	        </PropertyColumn>
 	        <TemplateColumn Title="Acciones" Filterable="false" Sortable="false">
 	            <CellTemplate>
-		            <MudTooltip Text="Editar" Arrow="true" Placement="Placement.Bottom" Color="Color.Primary" Delay="500">
-			            <MudIconButton OnClick="@context.Actions.StartEditingItemAsync"
-			                           Disabled="@(!context.Item.IsStudentActive)"
-			                           Icon="@Icons.Material.Outlined.Edit" Size="@Size.Small" Color="Color.Primary" />
-		            </MudTooltip>
+		            <AuthorizeView Policy="@nameof(StudentCreate)" Context="innerContext">
+			            <MudTooltip Text="Editar" Arrow="true" Placement="Placement.Bottom" Color="Color.Primary" Delay="500">
+				            <MudIconButton OnClick="@context.Actions.StartEditingItemAsync"
+				                           Disabled="@(!context.Item.IsStudentActive)"
+				                           Icon="@Icons.Material.Outlined.Edit" Size="@Size.Small" Color="Color.Primary" />
+			            </MudTooltip>
+		            </AuthorizeView>
 	            </CellTemplate>
             </TemplateColumn>
         </Columns>

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentsList.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentsList.razor.cs
@@ -1,4 +1,5 @@
-﻿using Fonbec.Web.DataAccess.Entities.Enums;
+﻿using Fonbec.Web.DataAccess.Constants;
+using Fonbec.Web.DataAccess.Entities.Enums;
 using Fonbec.Web.Logic.ExtensionMethods;
 using Fonbec.Web.Logic.Models.Students;
 using Fonbec.Web.Logic.Models.Students.Input;
@@ -8,7 +9,7 @@ using MudBlazor;
 
 namespace Fonbec.Web.Ui.Components.Pages.Students;
 
-[PageMetadata(nameof(StudentsList), "Lista de becarios")]
+[PageMetadata(nameof(StudentsList), "Lista de becarios", [FonbecRole.Manager])]
 public partial class StudentsList : AuthenticationRequiredComponentBase
 {
     private List<StudentsListViewModel> _viewModels = [];

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentsList.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Students/StudentsList.razor.cs
@@ -8,12 +8,13 @@ using MudBlazor;
 
 namespace Fonbec.Web.Ui.Components.Pages.Students;
 
+[PageMetadata(nameof(StudentsList), "Lista de becarios")]
 public partial class StudentsList : AuthenticationRequiredComponentBase
 {
     private List<StudentsListViewModel> _viewModels = [];
 
-    private string[] _allEducationLevels = [];
-    private string[] _allFacilitators = [];
+    private IEnumerable<string> _allEducationLevels = [];
+    private IEnumerable<string> _allFacilitators = [];
 
     private string _searchString = string.Empty;
 
@@ -31,13 +32,11 @@ public partial class StudentsList : AuthenticationRequiredComponentBase
         _viewModels = await StudentService.GetAllStudentsAsync();
 
         _allEducationLevels = Enum.GetValues<EducationLevel>()
-            .Select(el => el.EnumToString())
-            .ToArray();
+            .Select(el => el.EnumToString());
 
         _allFacilitators = _viewModels.Select(vm => vm.FacilitatorFullName)
             .Distinct()
-            .OrderBy(fn => fn)
-            .ToArray();
+            .OrderBy(fn => fn);
 
         Loading = false;
     }

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserCreate.razor
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserCreate.razor
@@ -1,5 +1,5 @@
 ﻿@attribute [Route(NavRoutes.UserCreate)]
-@attribute [Authorize]
+@attribute [Authorize(Policy = nameof(UserCreate))]
 @inherits AuthenticationRequiredComponentBase
 
 @using Fonbec.Web.DataAccess.Constants

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserCreate.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserCreate.razor.cs
@@ -7,6 +7,7 @@ using MudBlazor;
 
 namespace Fonbec.Web.Ui.Components.Pages.Users;
 
+[PageMetadata(nameof(UserCreate), "Alta y actualización de usuarios")]
 public partial class UserCreate : AuthenticationRequiredComponentBase
 {
     private readonly UserCreateBindModel _bindModel = new();
@@ -72,8 +73,6 @@ public partial class UserCreate : AuthenticationRequiredComponentBase
             }
         }
 
-        var authenticatedUserId = await GetAuthenticatedUserIdAsync();
-
         var createUserInputModel = new CreateUserInputModel
         (
             _bindModel.UserChapterId,
@@ -84,7 +83,7 @@ public partial class UserCreate : AuthenticationRequiredComponentBase
             _bindModel.UserEmail,
             _bindModel.UserPhoneNumber,
             _bindModel.UserRole,
-            authenticatedUserId
+            CurrentUserId
         );
 
         var (createdUserId, errors) = await UserService.CreateUserAsync(createUserInputModel);

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserCreate.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserCreate.razor.cs
@@ -1,4 +1,5 @@
-﻿using Fonbec.Web.Logic.Models.Users.Input;
+﻿using Fonbec.Web.DataAccess.Constants;
+using Fonbec.Web.Logic.Models.Users.Input;
 using Fonbec.Web.Logic.Services;
 using Fonbec.Web.Ui.Constants;
 using Fonbec.Web.Ui.Models.User;
@@ -7,7 +8,7 @@ using MudBlazor;
 
 namespace Fonbec.Web.Ui.Components.Pages.Users;
 
-[PageMetadata(nameof(UserCreate), "Alta y actualización de usuarios")]
+[PageMetadata(nameof(UserCreate), "Crear y actualizar usuarios", [FonbecRole.Admin, FonbecRole.Manager])]
 public partial class UserCreate : AuthenticationRequiredComponentBase
 {
     private readonly UserCreateBindModel _bindModel = new();

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserPermissions.razor
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserPermissions.razor
@@ -1,0 +1,33 @@
+﻿@page "/usuarios/{userId:int}/permisos"
+@attribute [Authorize(Policy = nameof(UserPermissions))]
+@inherits AuthenticationRequiredComponentBase
+
+<PageHeader Title="Permisos" />
+
+<MudStack Row="true">
+	<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => SetAllTo(true))">
+		Todos
+	</MudButton>
+	<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => SetAllTo(false))">
+		Ninguno
+	</MudButton>
+	<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ResetChanges">
+		Deshacer cambios
+	</MudButton>
+</MudStack>
+
+@foreach (var claim in CheckBoxItems)
+{
+	<MudCheckBox T="bool" @bind-Value="claim.IsChecked" Label="@claim.Description" />
+}
+
+<MudStack Row="true" Class="mt-4">
+	<MudButton OnClick="Save"
+	           Variant="Variant.Filled" Color="Color.Primary">
+		Guardar
+	</MudButton>
+	<MudButton Href="@NavRoutes.Users"
+	           Variant="Variant.Filled" Color="Color.Default" Class="ml-2">
+		Cancelar
+	</MudButton>
+</MudStack>

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserPermissions.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserPermissions.razor.cs
@@ -1,0 +1,65 @@
+﻿using Fonbec.Web.Logic.Services;
+using Fonbec.Web.Ui.Authorization;
+using Fonbec.Web.Ui.Constants;
+using Fonbec.Web.Ui.Models.User;
+using Microsoft.AspNetCore.Components;
+
+namespace Fonbec.Web.Ui.Components.Pages.Users;
+
+[PageMetadata(nameof(UserPermissions), "Permisos de usuario")]
+public partial class UserPermissions : AuthenticationRequiredComponentBase
+{
+    private List<UserPermissionsBindModel> CheckBoxItems { get; } = [];
+
+    private readonly List<bool> _originalSelection = [];
+
+    [Parameter]
+    public int UserId { get; set; }
+
+    [Inject]
+    public List<PageAccessInfo> AllPages { get; set; } = null!;
+
+    [Inject]
+    public IUserService UserService { get; set; } = null!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        var fonbecAuthClaim = await UserService.GetFonbecAuthClaim(UserId);
+
+        foreach (var page in AllPages)
+        {
+            var checkBoxItem = new UserPermissionsBindModel
+            {
+                IsChecked = UserService.HasPermission(fonbecAuthClaim, page.Codename),
+                Page = page.Codename,
+                Description = page.Description,
+            };
+
+            CheckBoxItems.Add(checkBoxItem);
+
+            _originalSelection.Add(checkBoxItem.IsChecked);
+        }
+    }
+
+    private void SetAllTo(bool b) => CheckBoxItems.ForEach(cbi => cbi.IsChecked = b);
+
+    private void ResetChanges()
+    {
+        for (var index = 0; index < CheckBoxItems.Count; index++)
+        {
+            CheckBoxItems[index].IsChecked = _originalSelection[index];
+        }
+    }
+
+    private async Task Save()
+    {
+        var pages = CheckBoxItems.Where(ti => ti.IsChecked)
+            .Select(cbi => cbi.Page);
+
+        await UserService.SetFonbecAuthClaim(UserId, pages);
+
+        NavigationManager.NavigateTo(NavRoutes.Users);
+    }
+}

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserPermissions.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UserPermissions.razor.cs
@@ -1,12 +1,13 @@
-﻿using Fonbec.Web.Logic.Services;
-using Fonbec.Web.Ui.Authorization;
+﻿using Fonbec.Web.DataAccess.Constants;
+using Fonbec.Web.Logic.Authorization;
+using Fonbec.Web.Logic.Services;
 using Fonbec.Web.Ui.Constants;
 using Fonbec.Web.Ui.Models.User;
 using Microsoft.AspNetCore.Components;
 
 namespace Fonbec.Web.Ui.Components.Pages.Users;
 
-[PageMetadata(nameof(UserPermissions), "Permisos de usuario")]
+[PageMetadata(nameof(UserPermissions), "Permisos de usuario", [FonbecRole.Admin])]
 public partial class UserPermissions : AuthenticationRequiredComponentBase
 {
     private List<UserPermissionsBindModel> CheckBoxItems { get; } = [];

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UsersList.razor
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UsersList.razor
@@ -1,5 +1,5 @@
 ﻿@attribute [Route(NavRoutes.Users)]
-@attribute [Authorize]
+@attribute [Authorize(Policy = nameof(UsersList))]
 @inherits AuthenticationRequiredComponentBase
 
 @using Fonbec.Web.DataAccess.Constants
@@ -9,13 +9,15 @@
 <PageHeader Title="Usuarios" />
 
 <MudStack StretchItems="StretchItems.Middle" Row>
-    <MudTooltip Text="Alta de usuario"
-                Arrow="true" Placement="Placement.Right"
-                Color="Color.Primary">
-        <MudFab Href="@NavRoutes.UserCreate"
-                StartIcon="@Icons.Material.Filled.Add"
-                Color="Color.Primary" />
-    </MudTooltip>
+	<AuthorizeView Policy="@nameof(UserCreate)">
+		<MudTooltip Text="Alta de usuario"
+		            Arrow="true" Placement="Placement.Right"
+		            Color="Color.Primary">
+			<MudFab Href="@NavRoutes.UserCreate"
+			        StartIcon="@Icons.Material.Filled.Add"
+			        Color="Color.Primary" />
+		</MudTooltip>
+	</AuthorizeView>
     <MudSpacer />
     <MudSwitch @bind-Value="_isLastNameFirst" LabelPlacement="Placement.Left">
         @(_isLastNameFirst ? "Apellido, Nombre" : "Nombre Apellido")
@@ -50,7 +52,7 @@
                 <CellTemplate>
 	                <AuditableUserDisplay UsersListViewModel="context.Item"
 	                                      IsLastNameFirst="_isLastNameFirst"
-	                                      CurrentUserId="_userId" />
+	                                      CurrentUserId="CurrentUserId" />
                 </CellTemplate>
                 <EditTemplate>
                     <MudTextField T="string" @bind-Value="@context.Item.UserFirstName" Immediate="true"
@@ -126,30 +128,40 @@
             </PropertyColumn>
             <TemplateColumn Title="Acciones" Filterable="false" Sortable="false">
                 <CellTemplate>
-                    <MudTooltip Text="Editar" Arrow="true" Placement="Placement.Bottom" Color="Color.Primary" Delay="500">
-                        <MudIconButton OnClick="@context.Actions.StartEditingItemAsync"
-                                       Icon="@Icons.Material.Outlined.Edit" Size="@Size.Small" Color="Color.Primary" />
-                    </MudTooltip>
-                    @if (context.Item.IsUserActive)
-                    {
-                        <MudTooltip Text="Deshabilitar" Arrow="true" Placement="Placement.Bottom" Color="Color.Warning" Delay="500">
-                            <MudIconButton OnClick="@(async _ => await DisableUserAsync(context.Item))"
-                                           Icon="@Icons.Material.Outlined.Delete" Size="@Size.Small" Color="Color.Warning"
-                                           Disabled="@(context.Item.UserId == _userId || !context.Item.CanUserBeLockedOut)" />
-                        </MudTooltip>
-                    }
-                    else
-                    {
-                        <MudTooltip Text="Habilitar" Arrow="true" Placement="Placement.Bottom" Color="Color.Success" Delay="500">
-                            <MudIconButton OnClick="@(async _ => await ReenableUserAsync(context.Item))"
-                                           Icon="@Icons.Material.Outlined.RestoreFromTrash" Size="@Size.Small" Color="Color.Success" />
-                        </MudTooltip>
-                    }
-                    <MudTooltip Text="Eliminar" Arrow="true" Placement="Placement.Bottom" Color="Color.Error" Delay="500">
-                        <MudIconButton OnClick="@(async _ => await DeleteForeverAsync(context.Item))"
-                                       Icon="@Icons.Material.Outlined.DeleteForever" Size="@Size.Small" Color="Color.Error"
-                                       Disabled="@(context.Item.UserId == _userId || !context.Item.CanUserBeLockedOut)" />
-                    </MudTooltip>
+	                <AuthorizeView Policy="@nameof(UserCreate)" Context="innerContext">
+		                <MudTooltip Text="Editar" Arrow="true" Placement="Placement.Bottom" Color="Color.Primary" Delay="500">
+			                <MudIconButton OnClick="@context.Actions.StartEditingItemAsync"
+			                               Icon="@Icons.Material.Outlined.Edit" Size="@Size.Small" Color="Color.Primary" />
+		                </MudTooltip>
+	                </AuthorizeView>
+	                <AuthorizeView Policy="@nameof(UserPermissions)" Context="innerContext">
+		                <MudTooltip Text="Permisos" Arrow="true" Placement="Placement.Bottom" Color="Color.Primary" Delay="500">
+			                <MudIconButton Href="@NavRoutes.UsersUserIdPermissions(context.Item.UserId)"
+			                               Icon="@Icons.Material.Outlined.Checklist" Size="@Size.Small" Color="Color.Primary" />
+		                </MudTooltip>
+	                </AuthorizeView>
+	                <AuthorizeView Policy="@nameof(UserCreate)" Context="innerContext">
+	                    @if (context.Item.IsUserActive)
+	                    {
+	                        <MudTooltip Text="Deshabilitar" Arrow="true" Placement="Placement.Bottom" Color="Color.Warning" Delay="500">
+	                            <MudIconButton OnClick="@(async _ => await DisableUserAsync(context.Item))"
+	                                           Icon="@Icons.Material.Outlined.Delete" Size="@Size.Small" Color="Color.Warning"
+	                                           Disabled="@(context.Item.UserId == CurrentUserId || !context.Item.CanUserBeLockedOut)" />
+	                        </MudTooltip>
+	                    }
+	                    else
+	                    {
+	                        <MudTooltip Text="Habilitar" Arrow="true" Placement="Placement.Bottom" Color="Color.Success" Delay="500">
+	                            <MudIconButton OnClick="@(async _ => await ReenableUserAsync(context.Item))"
+	                                           Icon="@Icons.Material.Outlined.RestoreFromTrash" Size="@Size.Small" Color="Color.Success" />
+	                        </MudTooltip>
+	                    }
+	                    <MudTooltip Text="Eliminar" Arrow="true" Placement="Placement.Bottom" Color="Color.Error" Delay="500">
+		                    <MudIconButton OnClick="@(async _ => await DeleteForeverAsync(context.Item))"
+		                                   Icon="@Icons.Material.Outlined.DeleteForever" Size="@Size.Small" Color="Color.Error"
+		                                   Disabled="@(context.Item.UserId == CurrentUserId || !context.Item.CanUserBeLockedOut)" />
+	                    </MudTooltip>
+	                </AuthorizeView>
                 </CellTemplate>
             </TemplateColumn>
         </Columns>

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UsersList.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UsersList.razor.cs
@@ -8,17 +8,16 @@ using MudBlazor;
 
 namespace Fonbec.Web.Ui.Components.Pages.Users;
 
+[PageMetadata(nameof(UsersList), "Lista de usuarios")]
 public partial class UsersList : AuthenticationRequiredComponentBase
 {
     private List<UsersListViewModel> _viewModel = [];
-
-    private int _userId;
 
     private string _searchString = string.Empty;
 
     private bool _isLastNameFirst;
 
-    private string[] _allChapters = [];
+    private IEnumerable<string> _allChapters = [];
 
     [Inject]
     public IUserService UserService { get; set; } = null!;
@@ -28,16 +27,15 @@ public partial class UsersList : AuthenticationRequiredComponentBase
 
     protected override async Task OnInitializedAsync()
     {
-        Loading = true;
+        await base.OnInitializedAsync();
 
-        _userId = await GetAuthenticatedUserIdAsync();
+        Loading = true;
 
         _viewModel = await UserService.GetAllUsersAsync();
 
         _allChapters = _viewModel.Select(vm => vm.UserChapterName)
             .Distinct()
-            .OrderBy(ch => ch)
-            .ToArray();
+            .OrderBy(ch => ch);
 
         Loading = false;
     }
@@ -59,7 +57,7 @@ public partial class UsersList : AuthenticationRequiredComponentBase
             viewModel.UserGender,
             viewModel.UserEmail,
             viewModel.UserPhoneNumber,
-            _userId
+            CurrentUserId
         );
 
         var userUpdatedSuccessfully = await UserService.UpdateUserAsync(updateUserInputModel);
@@ -98,7 +96,7 @@ public partial class UsersList : AuthenticationRequiredComponentBase
             return;
         }
 
-        var disableUserInputModel = new DisableUserInputModel(viewModel.UserId, DisableUser: true, _userId);
+        var disableUserInputModel = new DisableUserInputModel(viewModel.UserId, DisableUser: true, CurrentUserId);
 
         var errors = await UserService.DisableUserAsync(disableUserInputModel);
 
@@ -122,7 +120,7 @@ public partial class UsersList : AuthenticationRequiredComponentBase
             return;
         }
 
-        var disableUserInputModel = new DisableUserInputModel(viewModel.UserId, DisableUser: false, _userId);
+        var disableUserInputModel = new DisableUserInputModel(viewModel.UserId, DisableUser: false, CurrentUserId);
         
         var errors = await UserService.DisableUserAsync(disableUserInputModel);
 

--- a/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UsersList.razor.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Components/Pages/Users/UsersList.razor.cs
@@ -8,7 +8,7 @@ using MudBlazor;
 
 namespace Fonbec.Web.Ui.Components.Pages.Users;
 
-[PageMetadata(nameof(UsersList), "Lista de usuarios")]
+[PageMetadata(nameof(UsersList), "Lista de usuarios", [FonbecRole.Admin, FonbecRole.Manager])]
 public partial class UsersList : AuthenticationRequiredComponentBase
 {
     private List<UsersListViewModel> _viewModel = [];

--- a/src/1-UI/Fonbec.Web.Ui/Configuration/ConfigureMiddleware.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Configuration/ConfigureMiddleware.cs
@@ -7,8 +7,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
+using Fonbec.Web.Logic.Authorization;
 using Fonbec.Web.Logic.Constants;
-using Fonbec.Web.Ui.Authorization;
 
 namespace Fonbec.Web.Ui.Configuration;
 

--- a/src/1-UI/Fonbec.Web.Ui/Configuration/ConfigureServices.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Configuration/ConfigureServices.cs
@@ -2,6 +2,7 @@
 using Fonbec.Web.DataAccess;
 using Fonbec.Web.DataAccess.Entities;
 using Fonbec.Web.DataAccess.Repositories;
+using Fonbec.Web.Logic.Authorization;
 using Fonbec.Web.Logic.Services;
 using Fonbec.Web.Logic.Util;
 using Fonbec.Web.Ui.Account.Communication;

--- a/src/1-UI/Fonbec.Web.Ui/Constants/NavRoutes.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Constants/NavRoutes.cs
@@ -13,4 +13,6 @@ public static class NavRoutes
     public const string Students = "/becarios";
 
     public const string StudentCreate = $"{Students}/alta";
+
+    public static string UsersUserIdPermissions(int userId) => $"{Users}/{userId}/permisos";
 }

--- a/src/1-UI/Fonbec.Web.Ui/Models/User/UserPermissionsBindModel.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Models/User/UserPermissionsBindModel.cs
@@ -1,0 +1,10 @@
+﻿namespace Fonbec.Web.Ui.Models.User;
+
+internal class UserPermissionsBindModel
+{
+    public bool IsChecked { get; set; }
+
+    public string Page { get; init; } = null!;
+
+    public string Description { get; init; } = null!;
+}

--- a/src/1-UI/Fonbec.Web.Ui/Program.cs
+++ b/src/1-UI/Fonbec.Web.Ui/Program.cs
@@ -54,6 +54,8 @@ ConfigureServices.RegisterOptions(builder.Services, builder.Configuration);
 
 ConfigureServices.RegisterServices(builder.Services, builder.Configuration);
 
+ConfigureServices.RegisterPolicies(builder.Services);
+
 ConfigureServices.RegisterEntityFrameworkCore(builder.Services, builder.Configuration);
 
 // Mapster (each business Model declares its own mapping)

--- a/src/2-Logic/Fonbec.Web.Logic/Authorization/PageAccessInfo.cs
+++ b/src/2-Logic/Fonbec.Web.Logic/Authorization/PageAccessInfo.cs
@@ -1,0 +1,3 @@
+﻿namespace Fonbec.Web.Logic.Authorization;
+
+public record PageAccessInfo(string Codename, string Description, string[] Roles);

--- a/src/2-Logic/Fonbec.Web.Logic/Constants/FonbecAuth.cs
+++ b/src/2-Logic/Fonbec.Web.Logic/Constants/FonbecAuth.cs
@@ -1,0 +1,6 @@
+﻿namespace Fonbec.Web.Logic.Constants;
+
+public static class FonbecAuth
+{
+    public const string ClaimType = "FonbecAuth";
+}

--- a/src/3-DataAccess/Fonbec.Web.DataAccess/Repositories/UserRepository.cs
+++ b/src/3-DataAccess/Fonbec.Web.DataAccess/Repositories/UserRepository.cs
@@ -185,8 +185,6 @@ public class UserRepository(UserManager<FonbecWebUser> userManager, IUserStore<F
             return (userId, errors);
         }
 
-        // TODO: Add claims
-
         // Get user ID
         var userIdString = await userManager.GetUserIdAsync(fonbecUser);
 

--- a/test/Fonbec.Web.Logic.Tests/Constants/FonbecAuthTests.cs
+++ b/test/Fonbec.Web.Logic.Tests/Constants/FonbecAuthTests.cs
@@ -1,0 +1,12 @@
+using Fonbec.Web.Logic.Constants;
+
+namespace Fonbec.Web.Logic.Tests.Constants;
+
+public class FonbecAuthTests
+{
+    [Fact]
+    public void ClaimType_IsFonbecAuth()
+    {
+        Assert.Equal("FonbecAuth", FonbecAuth.ClaimType);
+    }
+}

--- a/test/Fonbec.Web.Logic.Tests/Services/UserServiceTests.cs
+++ b/test/Fonbec.Web.Logic.Tests/Services/UserServiceTests.cs
@@ -1,14 +1,23 @@
 using System.Security.Claims;
 using FluentAssertions;
 using Fonbec.Web.DataAccess.Repositories;
+using Fonbec.Web.Logic.Authorization;
 using Fonbec.Web.Logic.Constants;
 using Fonbec.Web.Logic.Services;
+using Fonbec.Web.Logic.Util;
 using NSubstitute;
 
 namespace Fonbec.Web.Logic.Tests.Services;
 
 public class UserServiceTests
 {
+    private static List<PageAccessInfo> DummyPages =>
+    [
+        new("PageA", "Page A", ["Role1"]),
+        new("PageB", "Page B", ["Role1"]),
+        new("PageC", "Page C", ["Role2"])
+    ];
+
     [Fact]
     public void GetFonbecAuthClaim_ReturnsClaimValue_WhenClaimExists()
     {
@@ -17,7 +26,7 @@ public class UserServiceTests
         var claimsPrincipal = new ClaimsPrincipal(
             new ClaimsIdentity([new Claim(FonbecAuth.ClaimType, claimValue)])
         );
-        var userService = new UserService(null!, null!, null!);
+        var userService = new UserService(null!, null!, null!, DummyPages);
 
         // Act
         var result = userService.GetFonbecAuthClaim(claimsPrincipal);
@@ -31,7 +40,7 @@ public class UserServiceTests
     {
         // Arrange
         var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity());
-        var userService = new UserService(null!, null!, null!);
+        var userService = new UserService(null!, null!, null!, DummyPages);
 
         // Act
         var result = userService.GetFonbecAuthClaim(claimsPrincipal);
@@ -48,7 +57,7 @@ public class UserServiceTests
     public void HasPermission_ReturnsExpectedResult(string claimValue, string page, bool expected)
     {
         // Arrange
-        var userService = new UserService(null!, null!, null!);
+        var userService = new UserService(null!, null!, null!, DummyPages);
 
         // Act
         var result = userService.HasPermission(claimValue, page);
@@ -64,7 +73,7 @@ public class UserServiceTests
         const int userId = 42;
         var pages = new[] { "PageB", "PageA" };
         var userRepo = Substitute.For<IUserRepository>();
-        var userService = new UserService(userRepo, null!, null!);
+        var userService = new UserService(userRepo, null!, null!, DummyPages);
 
         // Act
         await userService.SetFonbecAuthClaim(userId, pages);
@@ -86,7 +95,7 @@ public class UserServiceTests
         const string expectedValue = "foo";
         var userRepo = Substitute.For<IUserRepository>();
         userRepo.GetUserClaim(userId.ToString(), claimType).Returns(expectedValue);
-        var userService = new UserService(userRepo, null!, null!);
+        var userService = new UserService(userRepo, null!, null!, DummyPages);
 
         // Act
         var result = await userService.GetUserClaim(userId, claimType);
@@ -103,12 +112,47 @@ public class UserServiceTests
         const string claimType = "TestClaim";
         const string claimValue = "bar";
         var userRepo = Substitute.For<IUserRepository>();
-        var userService = new UserService(userRepo, null!, null!);
+        var userService = new UserService(userRepo, null!, null!, DummyPages);
 
         // Act
         await userService.SetUserClaim(userId, claimType, claimValue);
 
         // Assert
         await userRepo.Received(1).SetUserClaim(userId.ToString(), claimType, claimValue);
+    }
+
+    [Fact]
+    public async Task CreateUserAsync_SetsCorrectClaims_ForRole()
+    {
+        // Arrange
+        var userRepo = Substitute.For<IUserRepository>();
+        var passwordGen = Substitute.For<IPasswordGeneratorWrapper>();
+        var emailSender = Substitute.For<IEmailMessageSender>();
+        var userService = new UserService(userRepo, passwordGen, emailSender, DummyPages);
+
+        var model = new Fonbec.Web.Logic.Models.Users.Input.CreateUserInputModel(
+            UserChapterId: 1,
+            UserFirstName: "John",
+            UserLastName: "Doe",
+            UserNickName: "JD",
+            UserGender: Fonbec.Web.DataAccess.Entities.Enums.Gender.Male,
+            UserEmail: "john@doe.com",
+            UserPhoneNumber: "1234567890",
+            UserRole: "Role1",
+            CreatedById: 99
+        );
+
+        passwordGen.GeneratePassword().Returns("TestPassword");
+        userRepo.CreateUserAsync(Arg.Any<Fonbec.Web.DataAccess.DataModels.Users.Input.CreateUserInputDataModel>()).Returns((42, new List<string>()));
+
+        // Act
+        await userService.CreateUserAsync(model);
+
+        // Assert
+        await userRepo.Received(1).SetUserClaim(
+            "42",
+            FonbecAuth.ClaimType,
+            "PageA,PageB"
+        );
     }
 }

--- a/test/Fonbec.Web.Logic.Tests/Services/UserServiceTests.cs
+++ b/test/Fonbec.Web.Logic.Tests/Services/UserServiceTests.cs
@@ -1,0 +1,114 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Fonbec.Web.DataAccess.Repositories;
+using Fonbec.Web.Logic.Constants;
+using Fonbec.Web.Logic.Services;
+using NSubstitute;
+
+namespace Fonbec.Web.Logic.Tests.Services;
+
+public class UserServiceTests
+{
+    [Fact]
+    public void GetFonbecAuthClaim_ReturnsClaimValue_WhenClaimExists()
+    {
+        // Arrange
+        const string claimValue = "PageA,PageB";
+        var claimsPrincipal = new ClaimsPrincipal(
+            new ClaimsIdentity([new Claim(FonbecAuth.ClaimType, claimValue)])
+        );
+        var userService = new UserService(null!, null!, null!);
+
+        // Act
+        var result = userService.GetFonbecAuthClaim(claimsPrincipal);
+
+        // Assert
+        result.Should().Be(claimValue);
+    }
+
+    [Fact]
+    public void GetFonbecAuthClaim_ReturnsNull_WhenClaimDoesNotExist()
+    {
+        // Arrange
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity());
+        var userService = new UserService(null!, null!, null!);
+
+        // Act
+        var result = userService.GetFonbecAuthClaim(claimsPrincipal);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("PageA,PageB,PageC", "PageB", true)]
+    [InlineData("PageA,PageB,PageC", "PageD", false)]
+    [InlineData("PageA , PageB , PageC", "PageB", true)]
+    [InlineData("", "PageA", false)]
+    public void HasPermission_ReturnsExpectedResult(string claimValue, string page, bool expected)
+    {
+        // Arrange
+        var userService = new UserService(null!, null!, null!);
+
+        // Act
+        var result = userService.HasPermission(claimValue, page);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task SetFonbecAuthClaim_OrdersPagesAndCallsSetUserClaim()
+    {
+        // Arrange
+        const int userId = 42;
+        var pages = new[] { "PageB", "PageA" };
+        var userRepo = Substitute.For<IUserRepository>();
+        var userService = new UserService(userRepo, null!, null!);
+
+        // Act
+        await userService.SetFonbecAuthClaim(userId, pages);
+
+        // Assert
+        await userRepo.Received(1).SetUserClaim(
+            userId.ToString(),
+            FonbecAuth.ClaimType,
+            "PageA,PageB"
+        );
+    }
+
+    [Fact]
+    public async Task GetUserClaim_DelegatesToRepository()
+    {
+        // Arrange
+        const int userId = 1;
+        const string claimType = "TestClaim";
+        const string expectedValue = "foo";
+        var userRepo = Substitute.For<IUserRepository>();
+        userRepo.GetUserClaim(userId.ToString(), claimType).Returns(expectedValue);
+        var userService = new UserService(userRepo, null!, null!);
+
+        // Act
+        var result = await userService.GetUserClaim(userId, claimType);
+
+        // Assert
+        result.Should().Be(expectedValue);
+    }
+
+    [Fact]
+    public async Task SetUserClaim_DelegatesToRepository()
+    {
+        // Arrange
+        const int userId = 1;
+        const string claimType = "TestClaim";
+        const string claimValue = "bar";
+        var userRepo = Substitute.For<IUserRepository>();
+        var userService = new UserService(userRepo, null!, null!);
+
+        // Act
+        await userService.SetUserClaim(userId, claimType, claimValue);
+
+        // Assert
+        await userRepo.Received(1).SetUserClaim(userId.ToString(), claimType, claimValue);
+    }
+}


### PR DESCRIPTION
[AB#44](https://dev.azure.com/fonbec/7c886795-fbb9-47d1-8b02-091ee7ebf55a/_workitems/edit/44)

- Introduce a custom authorization system using policies for each page, based on a new [PageMetadata] attribute applied to Blazor components.
- Add `FonbecPermissionHandler` and `FonbecPermissionRequirement` to enforce access control per page, using a custom "FonbecAuth" claim containing a comma-separated list of allowed page codenames.
- Implement `PageAccessDiscovery` to automatically discover all pages with permissions and register them as policies at startup.
- Update navigation and UI (NavMenu, UsersList, StudentsList, ChaptersList, etc.) to show or hide actions and links based on the current user's permissions using `AuthorizeView` with policy names.
- Add a new "User Permissions" page, allowing admins to view and edit which pages a user can access, with changes persisted as claims.
- Refactor `AuthenticationRequiredComponentBase` to cache the authenticated user ID and updated all usages to leverage this.
- Extend `UserService` and `UserRepository` to support reading and updating user claims for permissions.
- On initial admin user creation, all permissions are granted by default.
- Minor improvements to strongly-typed collections and code clarity.
- Unit test